### PR TITLE
Add failing test

### DIFF
--- a/tests/Migrations/BaseTest.php
+++ b/tests/Migrations/BaseTest.php
@@ -205,6 +205,10 @@ abstract class BaseTest extends TestCase
         return static::$driverCache[static::DRIVER] = $this->driver;
     }
 
+    /**
+     * @param string $directory
+     * @return AbstractTable[]
+     */
     protected function migrate(string $directory): array
     {
         $tokenizer = new Tokenizer(new TokenizerConfig([

--- a/tests/Migrations/Fixtures/Alter/PrimaryToBigint.php
+++ b/tests/Migrations/Fixtures/Alter/PrimaryToBigint.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Migrations\Tests\Fixtures\Alter;
+
+/**
+ * @Entity
+ */
+class PrimaryToBigint
+{
+    /**
+     * @Column(type=bigint, primary=true)
+     * @var int
+     */
+    protected $id;
+}

--- a/tests/Migrations/Fixtures/Init/PrimaryToBigint.php
+++ b/tests/Migrations/Fixtures/Init/PrimaryToBigint.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Migrations\Tests\Fixtures\Init;
+
+/**
+ * @Entity
+ */
+class PrimaryToBigint
+{
+    /**
+     * @Column(type=primary)
+     * @var int
+     */
+    protected $id;
+}

--- a/tests/Migrations/ReflectTest.php
+++ b/tests/Migrations/ReflectTest.php
@@ -40,6 +40,9 @@ abstract class ReflectTest extends BaseTest
         $this->assertCount(2, $this->migrator->getMigrations());
     }
 
+    /**
+     * @throws \Throwable
+     */
     public function testAlter(): void
     {
         $tables = $this->migrate(__DIR__ . '/Fixtures/Init');


### PR DESCRIPTION
When changing PK declaration from 
```php
@Column(type=primary)
```
to
```php 
@Column(type=bigint, primary=true)
```
tests fail with next error (reproduced on PostgreSQL)
```
Cycle\Migrations\Tests\Driver\Postgres\ReflectTest::testAlter
Column primary_to_primary_bigints.id has been changed
Failed asserting that false is true.

.../Cycle/migrations/tests/Migrations/BaseTest.php:339
.../Cycle/migrations/tests/Migrations/ReflectTest.php:67
```