### PR TITLE
Migrator class must accept DatabaseProviderInterface

### DIFF
--- a/src/Capsule.php
+++ b/src/Capsule.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace Cycle\Migrations;
 
-use Cycle\Database\Database;
 use Cycle\Database\DatabaseInterface;
 use Cycle\Database\Schema\AbstractTable;
 use Cycle\Database\TableInterface;
@@ -24,7 +23,7 @@ final class Capsule implements CapsuleInterface
 {
     private array $schemas = [];
 
-    public function __construct(private Database $database)
+    public function __construct(private DatabaseInterface $database)
     {
     }
 

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Cycle\Migrations;
 
 use Cycle\Database\Database;
-use Cycle\Database\DatabaseManager;
+use Cycle\Database\DatabaseProviderInterface;
 use Cycle\Database\Table;
 use Cycle\Migrations\Config\MigrationConfig;
 use Cycle\Migrations\Exception\MigrationException;
@@ -30,7 +30,7 @@ final class Migrator
 
     public function __construct(
         private MigrationConfig $config,
-        private DatabaseManager $dbal,
+        private DatabaseProviderInterface $dbal,
         private RepositoryInterface $repository
     ) {
     }

--- a/tests/Migrations/BaseTest.php
+++ b/tests/Migrations/BaseTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Cycle\Migrations\Tests;
 
+use Cycle\Database\DatabaseProviderInterface;
 use Cycle\Database\Driver\DriverInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -49,7 +50,7 @@ abstract class BaseTest extends TestCase
     protected ContainerInterface $container;
     protected Migrator $migrator;
     protected MigrationConfig $migrationConfig;
-    protected DatabaseManager $dbal;
+    protected DatabaseProviderInterface $dbal;
     protected Database $db;
     protected FileRepository $repository;
 
@@ -60,7 +61,7 @@ abstract class BaseTest extends TestCase
         }
 
         $this->container = new Container();
-        $this->dbal = $this->getDBAL($this->container);
+        $this->dbal = $this->getDBAL();
 
         $this->migrationConfig = new MigrationConfig(static::CONFIG);
 
@@ -157,7 +158,7 @@ abstract class BaseTest extends TestCase
         return $this->db->table($table)->getSchema();
     }
 
-    protected function getDBAL(ContainerInterface $container): DatabaseManager
+    protected function getDBAL(): DatabaseProviderInterface
     {
         $dbal = new DatabaseManager(
             new DatabaseConfig([
@@ -165,8 +166,7 @@ abstract class BaseTest extends TestCase
                 'aliases' => [],
                 'databases' => [],
                 'connections' => [],
-            ]),
-            $container
+            ])
         );
 
         $dbal->addDatabase(


### PR DESCRIPTION
Without this fix, Migrator uses its own `DatabaseManager` instance.

It's not a big deal in runtime since it's called separately and once, but on the user space it's not possible to run migrations in `tests` - migrator and app will each use their own respective DBAL instances.