### PR TITLE
feat: simplification Renderer->columnOptions output for datetime now

### DIFF
--- a/src/Atomizer/Renderer.php
+++ b/src/Atomizer/Renderer.php
@@ -401,6 +401,10 @@ final class Renderer implements RendererInterface
             $options['precision'] = $column->getPrecision();
         }
 
+        if ($options['default'] == $column::DATETIME_NOW){
+            $options['default'] = AbstractColumn::DATETIME_NOW;
+        }
+
         return $this->mountIndents($serializer->serialize($options));
     }
 

--- a/src/Atomizer/Renderer.php
+++ b/src/Atomizer/Renderer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cycle\Migrations\Atomizer;
 
+use Cycle\Database\Injection\Fragment;
 use Cycle\Database\Schema\AbstractColumn;
 use Cycle\Database\Schema\AbstractForeignKey;
 use Cycle\Database\Schema\AbstractIndex;
@@ -401,7 +402,7 @@ final class Renderer implements RendererInterface
             $options['precision'] = $column->getPrecision();
         }
 
-        if ($options['default'] == $column::DATETIME_NOW) {
+        if ($options['default'] === $column::DATETIME_NOW || ($options['default'] instanceof Fragment && (string)$options['default'] === $column::DATETIME_NOW)) {
             $options['default'] = AbstractColumn::DATETIME_NOW;
         }
 

--- a/src/Atomizer/Renderer.php
+++ b/src/Atomizer/Renderer.php
@@ -401,7 +401,7 @@ final class Renderer implements RendererInterface
             $options['precision'] = $column->getPrecision();
         }
 
-        if ($options['default'] == $column::DATETIME_NOW){
+        if ($options['default'] == $column::DATETIME_NOW) {
             $options['default'] = AbstractColumn::DATETIME_NOW;
         }
 

--- a/src/Atomizer/Renderer.php
+++ b/src/Atomizer/Renderer.php
@@ -402,7 +402,8 @@ final class Renderer implements RendererInterface
             $options['precision'] = $column->getPrecision();
         }
 
-        if ($options['default'] === $column::DATETIME_NOW || ($options['default'] instanceof Fragment && (string)$options['default'] === $column::DATETIME_NOW)) {
+        $default = $options['default'];
+        if ($column::DATETIME_NOW === ($default instanceof \Stringable ? (string)$default : $default)) {
             $options['default'] = AbstractColumn::DATETIME_NOW;
         }
 

--- a/src/Atomizer/Renderer.php
+++ b/src/Atomizer/Renderer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Cycle\Migrations\Atomizer;
 
-use Cycle\Database\Injection\Fragment;
 use Cycle\Database\Schema\AbstractColumn;
 use Cycle\Database\Schema\AbstractForeignKey;
 use Cycle\Database\Schema\AbstractIndex;


### PR DESCRIPTION
Before
```php
            ->addColumn('created_at', 'datetime', [
                'nullable' => false,
                'default'  => \Cycle\Database\Injection\Fragment::__set_state(array(
               'fragment' => 'now()',
               'parameters' =>
              array (
                ),
                ))
            ])
```
After
```php
            ->addColumn('created_at', 'datetime', [
                'nullable' => false,
                'default'  => 'CURRENT_TIMESTAMP'
               )
            ])
```

CURRENT_TIMESTAMP will be translated for postgresql to now() in [AbstractColumn (cycle/database)](https://github.com/cycle/database/blob/2.x/src%2FSchema%2FAbstractColumn.php#L490) 