### PR TITLE
Fix MigrationException code param type

### DIFF
--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -144,7 +144,7 @@ final class Migrator
                         ),
                         $exception->getMessage()
                     ),
-                    $exception->getCode(),
+                    (int)$exception->getCode(),
                     $exception
                 );
             }


### PR DESCRIPTION
Fix "Exception::__construct(): Argument #2 ($code)
must be of type int, string given"