### PR TITLE
Adds ability to look for migrations in vendor packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .env
 .coveralls.yml
 composer.lock
-vendor/
+/vendor
 tests/runtime/*
 build/logs/*
 build/

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ composer require cycle/migrations ^3.0
 use Cycle\Migrations;
 use Cycle\Database;
 use Cycle\Database\Config;
+
 $dbal = new Database\DatabaseManager(new Config\DatabaseConfig([
     'default' => 'default',
     'databases' => [
@@ -35,16 +36,22 @@ $dbal = new Database\DatabaseManager(new Config\DatabaseConfig([
         ),
     ]
 ]));
+
 $config = new Migrations\Config\MigrationConfig([
     'directory' => __DIR__ . '/../migrations/',    // where to store migrations
-    'table'     => 'migrations'                    // database table to store migration status
-    'safe'      => true                            // When set to true no confirmation will be requested on migration run. 
+    'vendorDirectories' => [                       // Where to look for vendor package migrations
+        __DIR__ . '/../vendor/vendorName/packageName/migrations/'
+    ],
+    'table' => 'migrations'                       // database table to store migration status
+    'safe' => true                                // When set to true no confirmation will be requested on migration run. 
 ]);
+
 $migrator = new Migrations\Migrator(
     $config, 
     $dbal, 
     new Migrations\FileRepository($config)
 );
+
 // Init migration table
 $migrator->configure();
 ```

--- a/src/Config/MigrationConfig.php
+++ b/src/Config/MigrationConfig.php
@@ -19,6 +19,14 @@ final class MigrationConfig extends InjectableConfig
     }
 
     /**
+     * Vendor migrations directories.
+     */
+    public function getVendorDirectories(): array
+    {
+        return (array) ($this->config['vendorDirectories'] ?? []);
+    }
+
+    /**
      * Table to store list of executed migrations.
      */
     public function getTable(): string

--- a/src/FileRepository.php
+++ b/src/FileRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cycle\Migrations;
 
 use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\Rules\English\InflectorFactory;
 use Spiral\Core\Container;
 use Spiral\Core\FactoryInterface;
 use Spiral\Files\Files;
@@ -33,49 +34,50 @@ final class FileRepository implements RepositoryInterface
     {
         $this->files = new Files();
         $this->factory = $factory ?? new Container();
-        $this->inflector = (new \Doctrine\Inflector\Rules\English\InflectorFactory())->build();
+        $this->inflector = (new InflectorFactory())->build();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getMigrations(): array
     {
         $timestamps = [];
         $chunks = [];
         $migrations = [];
 
-        foreach ($this->getFiles() as $f) {
-            if (!class_exists($f['class'], false)) {
-                //Attempting to load migration class (we can not relay on autoloading here)
-                require_once($f['filename']);
+        $directories = \array_merge(
+            [$this->config->getDirectory()],
+            $this->config->getVendorDirectories()
+        );
+
+        foreach ($directories as $directory) {
+            foreach ($this->getFiles($directory) as $f) {
+                if (! \class_exists($f['class'], false)) {
+                    //Attempting to load migration class (we can not relay on autoloading here)
+                    require_once($f['filename']);
+                }
+
+                /** @var MigrationInterface $migration */
+                $migration = $this->factory->make($f['class']);
+
+                $timestamps[] = $f['created']->getTimestamp();
+                $chunks[] = $f['chunk'];
+                $migrations[] = $migration->withState(new State($f['name'], $f['created']));
             }
-
-            /** @var MigrationInterface $migration */
-            $migration = $this->factory->make($f['class']);
-
-            $timestamps[] = $f['created']->getTimestamp();
-            $chunks[] = $f['chunk'];
-            $migrations[] = $migration->withState(new State($f['name'], $f['created']));
         }
 
-        array_multisort($timestamps, $chunks, SORT_ASC | SORT_NATURAL, $migrations);
+        \array_multisort($timestamps, $chunks, SORT_ASC | SORT_NATURAL, $migrations);
 
         return $migrations;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function registerMigration(string $name, string $class, string $body = null): string
     {
-        if (empty($body) && !class_exists($class)) {
+        if (empty($body) && ! \class_exists($class)) {
             throw new RepositoryException(
                 "Unable to register migration '{$class}', representing class does not exists"
             );
         }
 
-        $currentTimeStamp = date(self::TIMESTAMP_FORMAT);
+        $currentTimeStamp = \date(self::TIMESTAMP_FORMAT);
         $inflectedName = $this->inflector->tableize($name);
 
         foreach ($this->getMigrations() as $migration) {
@@ -111,13 +113,13 @@ final class FileRepository implements RepositoryInterface
     /**
      * Internal method to fetch all migration filenames.
      */
-    private function getFiles(): \Generator
+    private function getFiles(string $directory): \Generator
     {
-        foreach ($this->files->getFiles($this->config->getDirectory(), '*.php') as $filename) {
+        foreach ($this->files->getFiles($directory, '*.php') as $filename) {
             $reflection = new ReflectionFile($filename);
-            $definition = explode('_', basename($filename));
+            $definition = \explode('_', \basename($filename));
 
-            if (count($definition) < 3) {
+            if (\count($definition) < 3) {
                 throw new RepositoryException("Invalid migration filename '{$filename}'");
             }
 
@@ -131,10 +133,10 @@ final class FileRepository implements RepositoryInterface
                 'class' => $reflection->getClasses()[0],
                 'created' => $created,
                 'chunk' => $definition[1],
-                'name' => str_replace(
+                'name' => \str_replace(
                     '.php',
                     '',
-                    implode('_', array_slice($definition, 2))
+                    \implode('_', \array_slice($definition, 2))
                 ),
             ];
         }
@@ -147,15 +149,15 @@ final class FileRepository implements RepositoryInterface
     {
         $name = $this->inflector->tableize($name);
 
-        $filename = sprintf(
+        $filename = \sprintf(
             self::FILENAME_FORMAT,
-            date(self::TIMESTAMP_FORMAT),
+            \date(self::TIMESTAMP_FORMAT),
             $this->chunkID++,
             $name
         );
 
         return $this->files->normalizePath(
-            $this->config->getDirectory() . FilesInterface::SEPARATOR . $filename
+            $this->config->getDirectory().FilesInterface::SEPARATOR.$filename
         );
     }
 }

--- a/src/FileRepository.php
+++ b/src/FileRepository.php
@@ -157,7 +157,7 @@ final class FileRepository implements RepositoryInterface
         );
 
         return $this->files->normalizePath(
-            $this->config->getDirectory().FilesInterface::SEPARATOR.$filename
+            $this->config->getDirectory() . FilesInterface::SEPARATOR . $filename
         );
     }
 }

--- a/tests/Migrations/BaseTest.php
+++ b/tests/Migrations/BaseTest.php
@@ -42,9 +42,10 @@ abstract class BaseTest extends TestCase
         'directory' => __DIR__ . '/../files/',
         'table' => 'migrations',
         'safe' => true,
+        'vendorDirectories' => __DIR__ . '/../files/vendor/',
     ];
 
-    public static array $config;
+    public static array $config = [];
     protected static array $driverCache = [];
     protected DriverInterface $driver;
     protected ContainerInterface $container;
@@ -56,7 +57,7 @@ abstract class BaseTest extends TestCase
 
     public function setUp(): void
     {
-        if (static::$config['debug']) {
+        if (static::$config['debug'] ?? false) {
             echo "\n\n-------- BEGIN: " . $this->getName() . " --------------\n\n";
         }
 
@@ -79,6 +80,10 @@ abstract class BaseTest extends TestCase
     {
         $files = new Files();
         foreach ($files->getFiles(__DIR__ . '/../files/', '*.php') as $file) {
+            $files->delete($file);
+            clearstatcache(true, $file);
+        }
+        foreach ($files->getFiles(__DIR__ . '/../files/vendor/', '*.php') as $file) {
             $files->delete($file);
             clearstatcache(true, $file);
         }

--- a/tests/Migrations/MigratorTest.php
+++ b/tests/Migrations/MigratorTest.php
@@ -61,7 +61,7 @@ abstract class MigratorTest extends BaseTest
         $this->assertSame([
             'A3Vendor', 'A1Vendor', 'A1', 'A2Vendor', 'A2', 'A3', 'A4Vendor', 'A4',
             'B1Vendor', 'B1', 'B2Vendor', 'B2', 'B3', 'B3Vendor',
-            'C', 'CVendor'
+            'C', 'CVendor',
         ], $classes);
     }
 

--- a/tests/Migrations/MigratorTest.php
+++ b/tests/Migrations/MigratorTest.php
@@ -29,9 +29,25 @@ abstract class MigratorTest extends BaseTest
             '20200923.040608_0_0_migration_3.php' => 'C',
             '20200909.030203_1_1_migration_1.php' => 'B1',
         ];
+
+        $vendorFiles = [
+            '20200908.024119_333_333_migration_1.php' => 'A3',
+            '20200909.030203_22_22_migration_1.php' => 'B2',
+            '20200910.030203_23_23_migration_1.php' => 'B3',
+            '20200909.024119_1_1_migration_1.php' => 'A1',
+            '20200909.024119_22_22_migration_2.php' => 'A2',
+            '20200909.024119_4444_4444_migration_2.php' => 'A4',
+            '20200856.040608_0_0_migration_3.php' => 'C',
+            '20200909.030203_1_1_migration_1.php' => 'B1',
+        ];
+
         $stub = file_get_contents(__DIR__ . '/../files/migration.stub');
         foreach ($files as $name => $class) {
             file_put_contents(__DIR__ . "/../files/$name", sprintf($stub, $class));
+        }
+
+        foreach ($vendorFiles as $name => $class) {
+            file_put_contents(__DIR__ . "/../files/vendor/$name", \sprintf($stub, $class . 'Vendor'));
         }
 
         $migrations = $this->repository->getMigrations();
@@ -42,7 +58,11 @@ abstract class MigratorTest extends BaseTest
             array_values($migrations)
         );
 
-        $this->assertSame(['A1', 'A2', 'A3', 'A4', 'B1', 'B2', 'B3', 'C'], $classes);
+        $this->assertSame([
+            'A3Vendor', 'A1Vendor', 'A1', 'A2Vendor', 'A2', 'A3', 'A4Vendor', 'A4',
+            'B1Vendor', 'B1', 'B2Vendor', 'B2', 'B3', 'B3Vendor',
+            'C', 'CVendor'
+        ], $classes);
     }
 
     public function testIsConfigured(): void


### PR DESCRIPTION
After this PR you will have an ability to specify directories with vendor migrations.

```php
$config = new Migrations\Config\MigrationConfig([
    'directory' => __DIR__ . '/../migrations/',    // where to store migrations
    'vendorDirectories' => [                       // Where to look for vendor package migrations
        __DIR__ . '/../vendor/vendorName/packageName/migrations/'
    ],
    'table' => 'migrations'                        // database table to store migration status
    'safe' => true                                 // When set to true no confirmation will be requested on migration run. 
]);
```