### PR TITLE
Fix TableBlueprint.php examples

### DIFF
--- a/src/TableBlueprint.php
+++ b/src/TableBlueprint.php
@@ -110,7 +110,7 @@ final class TableBlueprint
 
     /**
      * Example:
-     * $table->addForeignKey('user_id', 'users', 'id', ['delete' => 'CASCADE']);
+     * $table->addForeignKey(['user_id'], 'users', ['id'], ['delete' => 'CASCADE']);
      *
      * @param string $foreignTable Database isolation prefix will be automatically added.
      */
@@ -133,7 +133,7 @@ final class TableBlueprint
 
     /**
      * Example:
-     * $table->alterForeignKey('user_id', 'users', 'id', ['delete' => 'NO ACTION']);
+     * $table->alterForeignKey(['user_id'], 'users', ['id'], ['delete' => 'NO ACTION']);
      */
     public function alterForeignKey(
         array $columns,
@@ -154,7 +154,7 @@ final class TableBlueprint
 
     /**
      * Example:
-     * $table->dropForeignKey('user_id');
+     * $table->dropForeignKey(['user_id']);
      */
     public function dropForeignKey(array $columns): self
     {


### PR DESCRIPTION
Update of examples in foreignKeys. They accept arguments "columns" and "foreignKeys" which are type of array but example is type of string in both arguments

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

- Closes #<!-- add issue number here -->
- How was this tested:
  <!--- Please describe how you tested your changes/how we can test them -->
  <!-- - Added autotests -->
- Any docs updates needed?
  <!--- Provide a part of the documentation that should be updated
        or a link to related PR in the documentation repository -->
