### PR TITLE
Add rendering of column attributes

### DIFF
--- a/src/Atomizer/Renderer.php
+++ b/src/Atomizer/Renderer.php
@@ -252,6 +252,9 @@ final class Renderer implements RendererInterface
         }
 
         foreach ($column->getAttributes() as $attribute => $value) {
+            if ($attribute === 'size' && $value === 0) {
+                continue;
+            }
             $options[$attribute] = $value;
         }
 

--- a/src/Atomizer/Renderer.php
+++ b/src/Atomizer/Renderer.php
@@ -18,6 +18,7 @@ final class Renderer implements RendererInterface
      */
     public const NEW_STATE = 0;
     public const ORIGINAL_STATE = 1;
+    private const ALLOWED_ATTRIBUTES = ['scale', 'precision', 'unsigned', 'zerofill'];
 
     public function createTable(Method $method, AbstractTable $table): void
     {
@@ -255,9 +256,10 @@ final class Renderer implements RendererInterface
             $options['size'] = $column->getSize();
         }
 
-        if ($column->getAbstractType() === 'decimal') {
-            $options['scale'] = $column->getScale();
-            $options['precision'] = $column->getPrecision();
+        foreach ($column->getAttributes() as $attribute => $value) {
+            if (\in_array($attribute, self::ALLOWED_ATTRIBUTES, true)) {
+                $options[$attribute] = $value;
+            }
         }
 
         $default = $options['default'];

--- a/src/Atomizer/Renderer.php
+++ b/src/Atomizer/Renderer.php
@@ -18,7 +18,6 @@ final class Renderer implements RendererInterface
      */
     public const NEW_STATE = 0;
     public const ORIGINAL_STATE = 1;
-    private const ALLOWED_ATTRIBUTES = ['scale', 'precision', 'unsigned', 'zerofill'];
 
     public function createTable(Method $method, AbstractTable $table): void
     {
@@ -245,26 +244,20 @@ final class Renderer implements RendererInterface
     {
         $options = [
             'nullable' => $column->isNullable(),
-            'default' => $column->getDefaultValue(),
+            'defaultValue' => $column->getDefaultValue(),
         ];
 
         if ($column->getAbstractType() === 'enum') {
             $options['values'] = $column->getEnumValues();
         }
 
-        if ($column->getAbstractType() === 'string' || $column->getSize() > 0) {
-            $options['size'] = $column->getSize();
-        }
-
         foreach ($column->getAttributes() as $attribute => $value) {
-            if (\in_array($attribute, self::ALLOWED_ATTRIBUTES, true)) {
-                $options[$attribute] = $value;
-            }
+            $options[$attribute] = $value;
         }
 
-        $default = $options['default'];
+        $default = $options['defaultValue'];
         if ($column::DATETIME_NOW === ($default instanceof \Stringable ? (string)$default : $default)) {
-            $options['default'] = AbstractColumn::DATETIME_NOW;
+            $options['defaultValue'] = AbstractColumn::DATETIME_NOW;
         }
 
         return $options;

--- a/src/FileRepository.php
+++ b/src/FileRepository.php
@@ -53,7 +53,7 @@ final class FileRepository implements RepositoryInterface
         $migrations = [];
 
         foreach ($this->getFilesIterator() as $f) {
-            if (! \class_exists($f['class'], false)) {
+            if (!\class_exists($f['class'], false)) {
                 //Attempting to load migration class (we can not relay on autoloading here)
                 require_once($f['filename']);
             }
@@ -73,7 +73,7 @@ final class FileRepository implements RepositoryInterface
 
     public function registerMigration(string $name, string $class, string $body = null): string
     {
-        if (empty($body) && ! \class_exists($class)) {
+        if (empty($body) && !\class_exists($class)) {
             throw new RepositoryException(
                 "Unable to register migration '{$class}', representing class does not exists"
             );

--- a/src/Operation/Column/Column.php
+++ b/src/Operation/Column/Column.php
@@ -73,10 +73,8 @@ abstract class Column extends AbstractOperation
 
         if ($this->hasOption('defaultValue')) {
             $column->defaultValue($this->getOption('defaultValue', null));
-        }
-
         // @deprecated since v4.3
-        if ($this->hasOption('default')) {
+        } elseif ($this->hasOption('default')) {
             $column->defaultValue($this->getOption('default', null));
         }
 

--- a/src/Operation/Column/Column.php
+++ b/src/Operation/Column/Column.php
@@ -71,6 +71,11 @@ abstract class Column extends AbstractOperation
         $column->nullable($this->getOption('nullable', false));
         $column->setAttributes($this->options + $column->getAttributes());
 
+        if ($this->hasOption('defaultValue')) {
+            $column->defaultValue($this->getOption('defaultValue', null));
+        }
+
+        // @deprecated since v4.3
         if ($this->hasOption('default')) {
             $column->defaultValue($this->getOption('default', null));
         }

--- a/tests/Migrations/MySQL/AtomizerTest.php
+++ b/tests/Migrations/MySQL/AtomizerTest.php
@@ -45,4 +45,100 @@ class AtomizerTest extends \Cycle\Migrations\Tests\AtomizerTest
         $this->migrator->rollback();
         $this->assertFalse($this->db->hasTable('sample'));
     }
+
+    public function testUnsigned(): void
+    {
+        $this->migrator->configure();
+
+        $schema = $this->schema('sample');
+        $schema->primary('id');
+        $schema->integer('int');
+        $schema->integer('int_unsigned', unsigned: true);
+        $schema->tinyInteger('tiny_integer_unsigned', unsigned: true);
+        $schema->smallInteger('small_integer_unsigned', unsigned: true);
+        $schema->smallInteger('big_integer_unsigned', unsigned: true);
+        $this->atomize('migration1', [$schema]);
+
+        $this->migrator->run();
+        $this->assertFalse($this->schema('sample')->column('int')->isUnsigned());
+        $this->assertTrue($this->schema('sample')->column('int_unsigned')->isUnsigned());
+        $this->assertTrue($this->schema('sample')->column('tiny_integer_unsigned')->isUnsigned());
+        $this->assertTrue($this->schema('sample')->column('small_integer_unsigned')->isUnsigned());
+        $this->assertTrue($this->schema('sample')->column('big_integer_unsigned')->isUnsigned());
+
+        $schema = $this->schema('sample');
+        $schema->integer('int', unsigned: true);
+        $schema->integer('int_unsigned', unsigned: false);
+        $schema->tinyInteger('tiny_integer_unsigned', unsigned: false);
+        $schema->smallInteger('small_integer_unsigned', unsigned: false);
+        $schema->smallInteger('big_integer_unsigned', unsigned: false);
+        $this->atomize('migration2', [$schema]);
+
+        $this->migrator->run();
+
+        $this->assertTrue($this->schema('sample')->column('int')->isUnsigned());
+        $this->assertFalse($this->schema('sample')->column('int_unsigned')->isUnsigned());
+        $this->assertFalse($this->schema('sample')->column('tiny_integer_unsigned')->isUnsigned());
+        $this->assertFalse($this->schema('sample')->column('small_integer_unsigned')->isUnsigned());
+        $this->assertFalse($this->schema('sample')->column('big_integer_unsigned')->isUnsigned());
+
+        $this->migrator->rollback();
+
+        $this->assertFalse($this->schema('sample')->column('int')->isUnsigned());
+        $this->assertTrue($this->schema('sample')->column('int_unsigned')->isUnsigned());
+        $this->assertTrue($this->schema('sample')->column('tiny_integer_unsigned')->isUnsigned());
+        $this->assertTrue($this->schema('sample')->column('small_integer_unsigned')->isUnsigned());
+        $this->assertTrue($this->schema('sample')->column('big_integer_unsigned')->isUnsigned());
+
+        $this->migrator->rollback();
+        $this->assertFalse($this->db->hasTable('sample'));
+    }
+
+    public function testZerofill(): void
+    {
+        $this->migrator->configure();
+
+        $schema = $this->schema('sample');
+        $schema->primary('id');
+        $schema->integer('int');
+        $schema->integer('int_zerofill', zerofill: true);
+        $schema->tinyInteger('tiny_integer_zerofill', zerofill: true);
+        $schema->smallInteger('small_integer_zerofill', zerofill: true);
+        $schema->smallInteger('big_integer_zerofill', zerofill: true);
+        $this->atomize('migration1', [$schema]);
+
+        $this->migrator->run();
+        $this->assertFalse($this->schema('sample')->column('int')->isZerofill());
+        $this->assertTrue($this->schema('sample')->column('int_zerofill')->isZerofill());
+        $this->assertTrue($this->schema('sample')->column('tiny_integer_zerofill')->isZerofill());
+        $this->assertTrue($this->schema('sample')->column('small_integer_zerofill')->isZerofill());
+        $this->assertTrue($this->schema('sample')->column('big_integer_zerofill')->isZerofill());
+
+        $schema = $this->schema('sample');
+        $schema->integer('int', zerofill: true);
+        $schema->integer('int_zerofill', zerofill: false);
+        $schema->tinyInteger('tiny_integer_zerofill', zerofill: false);
+        $schema->smallInteger('small_integer_zerofill', zerofill: false);
+        $schema->smallInteger('big_integer_zerofill', zerofill: false);
+        $this->atomize('migration2', [$schema]);
+
+        $this->migrator->run();
+
+        $this->assertTrue($this->schema('sample')->column('int')->isZerofill());
+        $this->assertFalse($this->schema('sample')->column('int_zerofill')->isZerofill());
+        $this->assertFalse($this->schema('sample')->column('tiny_integer_zerofill')->isZerofill());
+        $this->assertFalse($this->schema('sample')->column('small_integer_zerofill')->isZerofill());
+        $this->assertFalse($this->schema('sample')->column('big_integer_zerofill')->isZerofill());
+
+        $this->migrator->rollback();
+
+        $this->assertFalse($this->schema('sample')->column('int')->isZerofill());
+        $this->assertTrue($this->schema('sample')->column('int_zerofill')->isZerofill());
+        $this->assertTrue($this->schema('sample')->column('tiny_integer_zerofill')->isZerofill());
+        $this->assertTrue($this->schema('sample')->column('small_integer_zerofill')->isZerofill());
+        $this->assertTrue($this->schema('sample')->column('big_integer_zerofill')->isZerofill());
+
+        $this->migrator->rollback();
+        $this->assertFalse($this->db->hasTable('sample'));
+    }
 }


### PR DESCRIPTION
## What was changed

The ability to render column attributes as options in migrations has been added. This fixes the issue with MySQL **unsigned** and **zerofill**.

Related to: https://github.com/orgs/cycle/discussions/456

Example of generated code:

```php
$this->table('test')
    ->addColumn('id', 'primary', [
        'nullable' => false,
        'defaultValue' => null,
        'size' => 11,
        'autoIncrement' => true,
        'unsigned' => false,
        'zerofill' => false,
    ])
    ->addColumn('unsigned', 'tinyInteger', [
        'nullable' => false,
        'defaultValue' => null,
        'size' => 4,
        'autoIncrement' => false,
        'unsigned' => true,
        'zerofill' => false,
    ])
    ->addColumn('zerofill', 'tinyInteger', [
        'nullable' => false,
        'defaultValue' => null,
        'size' => 4,
        'autoIncrement' => false,
        'unsigned' => false,
        'zerofill' => true,
    ])
    ->addColumn('int_size_attr', 'integer', [
        'nullable' => false,
        'defaultValue' => null,
        'size' => 4,
        'autoIncrement' => false,
        'unsigned' => false,
        'zerofill' => false,
    ])
    ->addColumn('int_size', 'integer', [
        'nullable' => false,
        'defaultValue' => null,
        'size' => 11,
        'autoIncrement' => false,
        'unsigned' => false,
        'zerofill' => false,
    ])
    ->addColumn('decimal_size_scale_attr', 'decimal', [
        'nullable' => false,
        'defaultValue' => null,
        'size' => 4,
        'precision' => 6,
        'scale' => 2,
    ])
    ->addColumn('decimal_size_scale_precision_attr', 'decimal', [
        'nullable' => false,
        'defaultValue' => null,
        'size' => 4,
        'precision' => 8,
        'scale' => 2,
    ])
    ->addColumn('decimal_size_scale', 'decimal', [
        'nullable' => false,
        'defaultValue' => null,
        'precision' => 4,
        'scale' => 2,
    ])
    ->addColumn('timestamp_size', 'timestamp', ['nullable' => false, 'defaultValue' => null, 'size' => 6])
    ->addColumn('timestamp_with_default', 'timestamp', [
        'nullable' => false,
        'defaultValue' => 'CURRENT_TIMESTAMP',
        'size' => 0,
   ])
   ->addColumn('string_size', 'string', ['nullable' => false, 'defaultValue' => 'foo', 'size' => 255])
   ->addColumn('username', 'string', ['nullable' => false, 'defaultValue' => null, 'size' => 255])
   ->addColumn('email', 'string', ['nullable' => false, 'defaultValue' => null, 'size' => 255])
   ->setPrimaryKeys(['id'])
   ->create();
```