### PR TITLE
Ignore `after` and `first` attributes with default values

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.4.0@04f312ac6ea48ba1c3e5db4d815bf6d74641c0ee">
+<files psalm-version="6.12.1@e71404b0465be25cf7f8a631b298c01c5ddd864f">
   <file src="src/Atomizer/Renderer.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$comparator]]></code>
@@ -12,6 +12,12 @@
       <code><![CDATA[$comparator]]></code>
       <code><![CDATA[$comparator]]></code>
     </ArgumentTypeCoercion>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function createTable(Method $method, AbstractTable $table): void]]></code>
+      <code><![CDATA[public function dropTable(Method $method, AbstractTable $table): void]]></code>
+      <code><![CDATA[public function revertTable(Method $method, AbstractTable $table): void]]></code>
+      <code><![CDATA[public function updateTable(Method $method, AbstractTable $table): void]]></code>
+    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$pair[self::NEW_STATE]]]></code>
       <code><![CDATA[$pair[self::NEW_STATE]]]></code>
@@ -65,6 +71,12 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[$table]]></code>
     </ArgumentTypeCoercion>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function execute(array $operations): void]]></code>
+      <code><![CDATA[public function getDatabase(): DatabaseInterface]]></code>
+      <code><![CDATA[public function getSchema(string $table): AbstractTable]]></code>
+      <code><![CDATA[public function getTable(string $table): TableInterface]]></code>
+    </MissingOverrideAttribute>
     <MixedPropertyTypeCoercion>
       <code><![CDATA[$this->schemas]]></code>
     </MixedPropertyTypeCoercion>
@@ -88,10 +100,54 @@
       <code><![CDATA[$this->config['table'] ?? 'migrations']]></code>
     </MixedReturnStatement>
   </file>
+  <file src="src/Exception/BlueprintException.php">
+    <ClassMustBeFinal>
+      <code><![CDATA[BlueprintException]]></code>
+    </ClassMustBeFinal>
+  </file>
+  <file src="src/Exception/CapsuleException.php">
+    <ClassMustBeFinal>
+      <code><![CDATA[CapsuleException]]></code>
+    </ClassMustBeFinal>
+  </file>
+  <file src="src/Exception/ContextException.php">
+    <ClassMustBeFinal>
+      <code><![CDATA[ContextException]]></code>
+    </ClassMustBeFinal>
+  </file>
+  <file src="src/Exception/Operation/ColumnException.php">
+    <ClassMustBeFinal>
+      <code><![CDATA[ColumnException]]></code>
+    </ClassMustBeFinal>
+  </file>
+  <file src="src/Exception/Operation/ForeignKeyException.php">
+    <ClassMustBeFinal>
+      <code><![CDATA[ForeignKeyException]]></code>
+    </ClassMustBeFinal>
+  </file>
+  <file src="src/Exception/Operation/IndexException.php">
+    <ClassMustBeFinal>
+      <code><![CDATA[IndexException]]></code>
+    </ClassMustBeFinal>
+  </file>
+  <file src="src/Exception/Operation/TableException.php">
+    <ClassMustBeFinal>
+      <code><![CDATA[TableException]]></code>
+    </ClassMustBeFinal>
+  </file>
+  <file src="src/Exception/RepositoryException.php">
+    <ClassMustBeFinal>
+      <code><![CDATA[RepositoryException]]></code>
+    </ClassMustBeFinal>
+  </file>
   <file src="src/FileRepository.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$directory]]></code>
     </ArgumentTypeCoercion>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function getMigrations(): array]]></code>
+      <code><![CDATA[public function registerMigration(string $name, string $class, ?string $body = null): string]]></code>
+    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$directory]]></code>
     </MixedArgument>
@@ -116,6 +172,12 @@
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->capsule->getDatabase()]]></code>
     </LessSpecificReturnStatement>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function getDatabase(): ?string]]></code>
+      <code><![CDATA[public function getState(): State]]></code>
+      <code><![CDATA[public function withCapsule(CapsuleInterface $capsule): MigrationInterface]]></code>
+      <code><![CDATA[public function withState(State $state): MigrationInterface]]></code>
+    </MissingOverrideAttribute>
     <MixedReturnStatement>
       <code><![CDATA[static::DATABASE]]></code>
     </MixedReturnStatement>
@@ -199,15 +261,26 @@
       <code><![CDATA[MigrationInterface]]></code>
     </UnnecessaryVarAnnotation>
   </file>
+  <file src="src/Operation/AbstractOperation.php">
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function getTable(): string]]></code>
+    </MissingOverrideAttribute>
+  </file>
   <file src="src/Operation/Column/Add.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$this->getTable()]]></code>
     </ArgumentTypeCoercion>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function execute(CapsuleInterface $capsule): void]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="src/Operation/Column/Alter.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$this->getTable()]]></code>
     </ArgumentTypeCoercion>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function execute(CapsuleInterface $capsule): void]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="src/Operation/Column/Column.php">
     <ArgumentTypeCoercion>
@@ -230,6 +303,9 @@
       <code><![CDATA[$this->getTable()]]></code>
       <code><![CDATA[$this->name]]></code>
     </ArgumentTypeCoercion>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function execute(CapsuleInterface $capsule): void]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="src/Operation/Column/Rename.php">
     <ArgumentTypeCoercion>
@@ -237,6 +313,9 @@
       <code><![CDATA[$this->name]]></code>
       <code><![CDATA[$this->newName]]></code>
     </ArgumentTypeCoercion>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function execute(CapsuleInterface $capsule): void]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="src/Operation/ForeignKey/Add.php">
     <ArgumentTypeCoercion>
@@ -255,6 +334,9 @@
                 $this->getOption('update', ForeignKeyInterface::NO_ACTION),
             )]]></code>
     </InvalidArgument>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function execute(CapsuleInterface $capsule): void]]></code>
+    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$fk]]></code>
       <code><![CDATA[$this->getOption('delete', ForeignKeyInterface::NO_ACTION)]]></code>
@@ -295,6 +377,9 @@
                 $this->getOption('update', ForeignKeyInterface::NO_ACTION),
             )]]></code>
     </InvalidArgument>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function execute(CapsuleInterface $capsule): void]]></code>
+    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$fk]]></code>
       <code><![CDATA[$this->getOption('delete', ForeignKeyInterface::NO_ACTION)]]></code>
@@ -320,6 +405,9 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[$this->getTable()]]></code>
     </ArgumentTypeCoercion>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function execute(CapsuleInterface $capsule): void]]></code>
+    </MissingOverrideAttribute>
   </file>
   <file src="src/Operation/ForeignKey/ForeignKey.php">
     <MixedArgumentTypeCoercion>
@@ -330,6 +418,9 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[$this->getTable()]]></code>
     </ArgumentTypeCoercion>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function execute(CapsuleInterface $capsule): void]]></code>
+    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$this->getOption('name')]]></code>
       <code><![CDATA[$this->getOption('unique', false)]]></code>
@@ -342,6 +433,9 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[$this->getTable()]]></code>
     </ArgumentTypeCoercion>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function execute(CapsuleInterface $capsule): void]]></code>
+    </MissingOverrideAttribute>
     <MixedArgument>
       <code><![CDATA[$this->getOption('unique', false)]]></code>
     </MixedArgument>
@@ -353,6 +447,9 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[$this->getTable()]]></code>
     </ArgumentTypeCoercion>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function execute(CapsuleInterface $capsule): void]]></code>
+    </MissingOverrideAttribute>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$this->columns]]></code>
     </MixedArgumentTypeCoercion>
@@ -361,25 +458,43 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[$this->getTable()]]></code>
     </ArgumentTypeCoercion>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function execute(CapsuleInterface $capsule): void]]></code>
+    </MissingOverrideAttribute>
     <MixedAssignment>
       <code><![CDATA[$database]]></code>
     </MixedAssignment>
+    <UndefinedThisPropertyFetch>
+      <code><![CDATA[$this->database]]></code>
+    </UndefinedThisPropertyFetch>
   </file>
   <file src="src/Operation/Table/Drop.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$this->getTable()]]></code>
     </ArgumentTypeCoercion>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function execute(CapsuleInterface $capsule): void]]></code>
+    </MissingOverrideAttribute>
     <MixedAssignment>
       <code><![CDATA[$database]]></code>
     </MixedAssignment>
+    <UndefinedThisPropertyFetch>
+      <code><![CDATA[$this->database]]></code>
+    </UndefinedThisPropertyFetch>
   </file>
   <file src="src/Operation/Table/PrimaryKeys.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$this->getTable()]]></code>
     </ArgumentTypeCoercion>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function execute(CapsuleInterface $capsule): void]]></code>
+    </MissingOverrideAttribute>
     <MixedAssignment>
       <code><![CDATA[$database]]></code>
     </MixedAssignment>
+    <UndefinedThisPropertyFetch>
+      <code><![CDATA[$this->database]]></code>
+    </UndefinedThisPropertyFetch>
   </file>
   <file src="src/Operation/Table/Rename.php">
     <ArgumentTypeCoercion>
@@ -387,17 +502,29 @@
       <code><![CDATA[$this->newName]]></code>
       <code><![CDATA[$this->newName]]></code>
     </ArgumentTypeCoercion>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function execute(CapsuleInterface $capsule): void]]></code>
+    </MissingOverrideAttribute>
     <MixedAssignment>
       <code><![CDATA[$database]]></code>
     </MixedAssignment>
+    <UndefinedThisPropertyFetch>
+      <code><![CDATA[$this->database]]></code>
+    </UndefinedThisPropertyFetch>
   </file>
   <file src="src/Operation/Table/Update.php">
     <ArgumentTypeCoercion>
       <code><![CDATA[$this->getTable()]]></code>
     </ArgumentTypeCoercion>
+    <MissingOverrideAttribute>
+      <code><![CDATA[public function execute(CapsuleInterface $capsule): void]]></code>
+    </MissingOverrideAttribute>
     <MixedAssignment>
       <code><![CDATA[$database]]></code>
     </MixedAssignment>
+    <UndefinedThisPropertyFetch>
+      <code><![CDATA[$this->database]]></code>
+    </UndefinedThisPropertyFetch>
   </file>
   <file src="src/Operation/Traits/OptionsTrait.php">
     <MixedArgument>

--- a/src/Atomizer/Renderer.php
+++ b/src/Atomizer/Renderer.php
@@ -256,6 +256,12 @@ final class Renderer implements RendererInterface
             if ($attribute === 'size' && $value === 0) {
                 continue;
             }
+            if ($attribute === 'after' && $value === '') {
+                continue;
+            }
+            if ($attribute === 'first' && $value === false) {
+                continue;
+            }
             $options[$attribute] = $value;
         }
 

--- a/tests/Migrations/MySQL/RendererTest.php
+++ b/tests/Migrations/MySQL/RendererTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Migrations\Tests\MySQL;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class RendererTest extends \Cycle\Migrations\Tests\RendererTest
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/Migrations/Postgres/RendererTest.php
+++ b/tests/Migrations/Postgres/RendererTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Migrations\Tests\Postgres;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class RendererTest extends \Cycle\Migrations\Tests\RendererTest
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/Migrations/RendererTest.php
+++ b/tests/Migrations/RendererTest.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Migrations\Tests;
+
+use Cycle\Database\Schema\AbstractColumn;
+use Cycle\Migrations\Atomizer\Renderer;
+
+abstract class RendererTest extends BaseTest
+{
+    public function testColumnOptionsForEnumColumn(): void
+    {
+        $column = $this->createMock(AbstractColumn::class);
+        $column->method('isNullable')->willReturn(true);
+        $column->method('getDefaultValue')->willReturn('one');
+        $column->method('getAttributes')->willReturn([]);
+        $column->method('getAbstractType')->willReturn('enum');
+        $column->method('getEnumValues')->willReturn(['one', 'two', 'three']);
+
+        $renderer = new Renderer();
+
+        $method = new \ReflectionMethod($renderer, 'columnOptions');
+        $method->setAccessible(true);
+
+        $options = $method->invoke($renderer, $column);
+
+        $this->assertArrayHasKey('nullable', $options);
+        $this->assertArrayHasKey('defaultValue', $options);
+        $this->assertArrayHasKey('values', $options);
+        $this->assertTrue($options['nullable']);
+        $this->assertSame('one', $options['defaultValue']);
+        $this->assertSame(['one', 'two', 'three'], $options['values']);
+    }
+
+    public function testColumnOptionsWithDateTimeNow(): void
+    {
+        $column = $this->createMock(AbstractColumn::class);
+        $column->method('isNullable')->willReturn(false);
+        $column->method('getDefaultValue')->willReturn(AbstractColumn::DATETIME_NOW);
+        $column->method('getAttributes')->willReturn([]);
+        $column->method('getAbstractType')->willReturn('datetime');
+
+        $renderer = new Renderer();
+
+        $method = new \ReflectionMethod($renderer, 'columnOptions');
+        $method->setAccessible(true);
+
+        $options = $method->invoke($renderer, $column);
+
+        $this->assertArrayHasKey('nullable', $options);
+        $this->assertArrayHasKey('defaultValue', $options);
+        $this->assertFalse($options['nullable']);
+        $this->assertSame(AbstractColumn::DATETIME_NOW, $options['defaultValue']);
+    }
+
+    public function testColumnOptionsSizeNotZeroIsAccepted(): void
+    {
+        $column = $this->createMock(AbstractColumn::class);
+        $column->method('isNullable')->willReturn(true);
+        $column->method('getDefaultValue')->willReturn(null);
+        $column->method('getAttributes')->willReturn(['size' => 11]);
+        $column->method('getAbstractType')->willReturn('integer');
+
+        $renderer = new Renderer();
+
+        $method = new \ReflectionMethod($renderer, 'columnOptions');
+        $method->setAccessible(true);
+
+        $options = $method->invoke($renderer, $column);
+
+        $this->assertArrayHasKey('nullable', $options);
+        $this->assertArrayHasKey('defaultValue', $options);
+        $this->assertArrayHasKey('size', $options);
+        $this->assertTrue($options['nullable']);
+        $this->assertNull($options['defaultValue']);
+        $this->assertSame(11, $options['size']);
+    }
+
+    public function testColumnOptionsSizeZeroIsIgnored(): void
+    {
+        $column = $this->createMock(AbstractColumn::class);
+        $column->method('isNullable')->willReturn(true);
+        $column->method('getDefaultValue')->willReturn(null);
+        $column->method('getAttributes')->willReturn(['size' => 0]);
+        $column->method('getAbstractType')->willReturn('integer');
+
+        $renderer = new Renderer();
+
+        $method = new \ReflectionMethod($renderer, 'columnOptions');
+        $method->setAccessible(true);
+
+        $options = $method->invoke($renderer, $column);
+
+        $this->assertArrayHasKey('nullable', $options);
+        $this->assertArrayHasKey('defaultValue', $options);
+        $this->assertArrayNotHasKey('size', $options);
+        $this->assertTrue($options['nullable']);
+        $this->assertNull($options['defaultValue']);
+    }
+
+    public function testColumnOptionsAfterNotEmptyStringIsAccepted(): void
+    {
+        $column = $this->createMock(AbstractColumn::class);
+        $column->method('isNullable')->willReturn(true);
+        $column->method('getDefaultValue')->willReturn(null);
+        $column->method('getAttributes')->willReturn(['after' => 'email']);
+        $column->method('getAbstractType')->willReturn('integer');
+
+        $renderer = new Renderer();
+
+        $method = new \ReflectionMethod($renderer, 'columnOptions');
+        $method->setAccessible(true);
+
+        $options = $method->invoke($renderer, $column);
+
+        $this->assertArrayHasKey('nullable', $options);
+        $this->assertArrayHasKey('defaultValue', $options);
+        $this->assertArrayHasKey('after', $options);
+        $this->assertTrue($options['nullable']);
+        $this->assertNull($options['defaultValue']);
+        $this->assertSame('email', $options['after']);
+    }
+
+    public function testColumnOptionsAfterEmptyStringIsIgnored(): void
+    {
+        $column = $this->createMock(AbstractColumn::class);
+        $column->method('isNullable')->willReturn(true);
+        $column->method('getDefaultValue')->willReturn(null);
+        $column->method('getAttributes')->willReturn(['after' => '']);
+        $column->method('getAbstractType')->willReturn('integer');
+
+        $renderer = new Renderer();
+
+        $method = new \ReflectionMethod($renderer, 'columnOptions');
+        $method->setAccessible(true);
+
+        $options = $method->invoke($renderer, $column);
+
+        $this->assertArrayHasKey('nullable', $options);
+        $this->assertArrayHasKey('defaultValue', $options);
+        $this->assertArrayNotHasKey('after', $options);
+        $this->assertTrue($options['nullable']);
+        $this->assertNull($options['defaultValue']);
+    }
+
+    public function testColumnOptionsFirstNotFalseIsAccepted(): void
+    {
+        $column = $this->createMock(AbstractColumn::class);
+        $column->method('isNullable')->willReturn(true);
+        $column->method('getDefaultValue')->willReturn(null);
+        $column->method('getAttributes')->willReturn(['first' => true]);
+        $column->method('getAbstractType')->willReturn('integer');
+
+        $renderer = new Renderer();
+
+        $method = new \ReflectionMethod($renderer, 'columnOptions');
+        $method->setAccessible(true);
+
+        $options = $method->invoke($renderer, $column);
+
+        $this->assertArrayHasKey('nullable', $options);
+        $this->assertArrayHasKey('defaultValue', $options);
+        $this->assertArrayHasKey('first', $options);
+        $this->assertTrue($options['nullable']);
+        $this->assertNull($options['defaultValue']);
+        $this->assertTrue($options['first']);
+    }
+
+    public function testColumnOptionsFirstFalseIsIgnored(): void
+    {
+        $column = $this->createMock(AbstractColumn::class);
+        $column->method('isNullable')->willReturn(true);
+        $column->method('getDefaultValue')->willReturn(null);
+        $column->method('getAttributes')->willReturn(['first' => false]);
+        $column->method('getAbstractType')->willReturn('integer');
+
+        $renderer = new Renderer();
+
+        $method = new \ReflectionMethod($renderer, 'columnOptions');
+        $method->setAccessible(true);
+
+        $options = $method->invoke($renderer, $column);
+
+        $this->assertArrayHasKey('nullable', $options);
+        $this->assertArrayHasKey('defaultValue', $options);
+        $this->assertArrayNotHasKey('first', $options);
+        $this->assertTrue($options['nullable']);
+        $this->assertNull($options['defaultValue']);
+    }
+}

--- a/tests/Migrations/SQLServer/RendererTest.php
+++ b/tests/Migrations/SQLServer/RendererTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Migrations\Tests\SQLServer;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class RendererTest extends \Cycle\Migrations\Tests\RendererTest
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/Migrations/SQLite/RendererTest.php
+++ b/tests/Migrations/SQLite/RendererTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Spiral Framework.
+ *
+ * @license   MIT
+ * @author    Anton Titov (Wolfy-J)
+ */
+
+declare(strict_types=1);
+
+namespace Cycle\Migrations\Tests\SQLite;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class RendererTest extends \Cycle\Migrations\Tests\RendererTest
+{
+    public const DRIVER = 'sqlite';
+}


### PR DESCRIPTION
Since the pull request https://github.com/cycle/database/pull/226 has been merged, it might be a good idea to ignore the `first` and `after` attributes when equaling the default values? So migrations are not declaring them for every column when not needed.

## 🔍 What was changed

* Added logic to ignore the `first` and `after` attributes when equaling the default values.
* Added some test cases (using Reflection) for the `Renderer::columnOptions` method.

## 🤔 Why?

When thinking about how column positioning would be used in migrations, I'm of the opinion they would be defined manually. As in I can't imagine defining this for an entity, instead I'd likely generate a migration, say containing an added column and then modify the options to position the new column after and existing column, to suit an order I prefer.

```php
    public function up(): void
    {
        $this->table('api_key')->addColumn('expires_at', 'datetime', [
            'nullable' => true,
            'defaultValue' => null,
            'comment' => 'Date and time API key will expire',
            'after' => 'updated_at',
        ]);
    }
```

## 📝 Checklist

- How was this tested:
  - [x] Unit tests added

