### PR TITLE
Fix handling of executed migrations with the withDatetimeMicroseconds driver option

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -222,22 +222,9 @@
     <MixedAssignment>
       <code><![CDATA[$migrationData]]></code>
       <code><![CDATA[$migrationData]]></code>
-      <code><![CDATA[$schema]]></code>
     </MixedAssignment>
     <MixedMethodCall>
       <code><![CDATA[count]]></code>
-      <code><![CDATA[datetime]]></code>
-      <code><![CDATA[datetime]]></code>
-      <code><![CDATA[datetime]]></code>
-      <code><![CDATA[datetime]]></code>
-      <code><![CDATA[dropIndex]]></code>
-      <code><![CDATA[hasIndex]]></code>
-      <code><![CDATA[index]]></code>
-      <code><![CDATA[nullable]]></code>
-      <code><![CDATA[primary]]></code>
-      <code><![CDATA[save]]></code>
-      <code><![CDATA[string]]></code>
-      <code><![CDATA[unique]]></code>
       <code><![CDATA[where]]></code>
     </MixedMethodCall>
     <MoreSpecificReturnType>
@@ -254,7 +241,6 @@
       <code><![CDATA[select]]></code>
     </TooManyArguments>
     <UndefinedInterfaceMethod>
-      <code><![CDATA[getSchema]]></code>
       <code><![CDATA[select]]></code>
     </UndefinedInterfaceMethod>
     <UnnecessaryVarAnnotation>

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -8,6 +8,7 @@ use Cycle\Database\Database;
 use Cycle\Database\DatabaseInterface;
 use Cycle\Database\DatabaseManager;
 use Cycle\Database\DatabaseProviderInterface;
+use Cycle\Database\Schema\AbstractTable;
 use Cycle\Database\Table;
 use Cycle\Migrations\Config\MigrationConfig;
 use Cycle\Migrations\Exception\MigrationException;
@@ -62,19 +63,12 @@ final class Migrator
         }
 
         foreach ($this->getDatabases() as $db) {
-            $schema = $db->table($this->config->getTable())->getSchema();
+            $table = $db->table($this->config->getTable());
+            \assert($table instanceof Table);
+            $schema = $table->getSchema();
 
             // Schema update will automatically sync all needed data
-            $schema->primary('id');
-            $schema->string('migration', 191)->nullable(false);
-            $schema->datetime('time_executed')->datetime();
-            $schema->datetime('created_at')->datetime();
-            $schema->index(['migration', 'created_at'])
-                ->unique(true);
-
-            if ($schema->hasIndex(['migration'])) {
-                $schema->dropIndex(['migration']);
-            }
+            $this->declareMigrationTableSchema($schema);
 
             $schema->save();
         }
@@ -229,7 +223,16 @@ final class Migrator
             }
         }
 
-        return !(!$table->hasIndex(['migration', 'created_at']));
+        if (!$table->hasIndex(['migration', 'created_at'])) {
+            return false;
+        }
+
+        // The table may have been created by a previous version of the package
+        // with a different column definition (e.g. datetime precision).
+        $schema = $table->getSchema();
+        $this->declareMigrationTableSchema($schema);
+
+        return !$schema->getComparator()->hasChanges();
     }
 
     /**
@@ -305,6 +308,26 @@ final class Migrator
             $migration->getState()->getTimeCreated()->format(self::DB_DATE_FORMAT),
             $db->getDriver()->getTimezone(),
         );
+    }
+
+    /**
+     * Declare the desired structure of the migration table on the given schema.
+     */
+    private function declareMigrationTableSchema(AbstractTable $schema): void
+    {
+        $schema->primary('id');
+        $schema->string('migration', 191)->nullable(false);
+        // Second precision is enough for migrations; size is set to keep the column
+        // type compatible with the `withDatetimeMicroseconds` driver option
+        // (on SQL Server the legacy DATETIME type rejects values with microseconds)
+        $schema->datetime('time_executed')->datetime(6);
+        $schema->datetime('created_at')->datetime(6);
+        $schema->index(['migration', 'created_at'])
+            ->unique(true);
+
+        if ($schema->hasIndex(['migration'])) {
+            $schema->dropIndex(['migration']);
+        }
     }
 
     /**

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -242,7 +242,7 @@ final class Migrator
             ->where(
                 [
                     'migration' => $migration->getState()->getName(),
-                    'created_at' => $this->getMigrationCreatedAtForDb($migration)->format(self::DB_DATE_FORMAT),
+                    'created_at' => $this->getMigrationCreatedAtForDb($migration),
                 ],
             )
             ->run()

--- a/tests/Migrations/DatetimeMicrosecondsTest.php
+++ b/tests/Migrations/DatetimeMicrosecondsTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Migrations\Tests;
+
+use Cycle\Database\Driver\DriverInterface;
+use Cycle\Migrations\Migration;
+use Cycle\Migrations\State;
+use Psr\Log\LoggerAwareInterface;
+
+/**
+ * The Migrator must correctly resolve the state of executed migrations
+ * when the driver is configured with the `withDatetimeMicroseconds` option.
+ *
+ * @see https://github.com/cycle/migrations/issues/66
+ */
+abstract class DatetimeMicrosecondsTest extends BaseTest
+{
+    public function getDriver(): DriverInterface
+    {
+        if (!isset($this->driver)) {
+            $config = clone self::$config[static::DRIVER];
+            $config->options['withDatetimeMicroseconds'] = true;
+
+            $this->driver = $config->driver::create($config);
+        }
+
+        if (self::$config['debug'] && $this->driver instanceof LoggerAwareInterface) {
+            $this->driver->setLogger(new TestLogger());
+        }
+
+        return $this->driver;
+    }
+
+    public function testMigrationResolvedAsExecutedAfterRun(): void
+    {
+        $this->migrator->configure();
+
+        $schema = $this->schema('sample');
+        $schema->primary('id');
+        $schema->integer('value');
+        $this->atomize('migration1', [$schema]);
+
+        $migration = $this->migrator->run();
+
+        $this->assertInstanceOf(Migration::class, $migration);
+        $this->assertSame(State::STATUS_EXECUTED, $migration->getState()->getStatus());
+    }
+
+    public function testSecondRunHasNothingToExecute(): void
+    {
+        $this->migrator->configure();
+
+        $schema = $this->schema('sample');
+        $schema->primary('id');
+        $schema->integer('value');
+        $this->atomize('migration1', [$schema]);
+
+        $this->migrator->run();
+
+        // The only migration has been executed, nothing is pending
+        $this->assertNull($this->migrator->run());
+    }
+
+    public function testRollbackAfterRun(): void
+    {
+        $this->migrator->configure();
+
+        $schema = $this->schema('sample');
+        $schema->primary('id');
+        $schema->integer('value');
+        $this->atomize('migration1', [$schema]);
+
+        $this->migrator->run();
+        $this->assertTrue($this->db->hasTable('sample'));
+
+        $migration = $this->migrator->rollback();
+
+        $this->assertInstanceOf(Migration::class, $migration);
+        $this->assertFalse($this->db->hasTable('sample'));
+    }
+}

--- a/tests/Migrations/DatetimeMicrosecondsTest.php
+++ b/tests/Migrations/DatetimeMicrosecondsTest.php
@@ -63,6 +63,33 @@ abstract class DatetimeMicrosecondsTest extends BaseTest
         $this->assertNull($this->migrator->run());
     }
 
+    public function testUpgradeFromLegacyTableStructure(): void
+    {
+        // The migration table as it was created by previous versions of the package:
+        // datetime columns without precision
+        $schema = $this->db->table('migrations')->getSchema();
+        $schema->primary('id');
+        $schema->string('migration', 191)->nullable(false);
+        $schema->datetime('time_executed')->datetime();
+        $schema->datetime('created_at')->datetime();
+        $schema->index(['migration', 'created_at'])->unique(true);
+        $schema->save();
+
+        $this->migrator->configure();
+        $this->assertTrue($this->migrator->isConfigured());
+
+        $schema = $this->schema('sample');
+        $schema->primary('id');
+        $schema->integer('value');
+        $this->atomize('migration1', [$schema]);
+
+        $migration = $this->migrator->run();
+
+        $this->assertInstanceOf(Migration::class, $migration);
+        $this->assertSame(State::STATUS_EXECUTED, $migration->getState()->getStatus());
+        $this->assertNull($this->migrator->run());
+    }
+
     public function testRollbackAfterRun(): void
     {
         $this->migrator->configure();

--- a/tests/Migrations/MySQL/DatetimeMicrosecondsTest.php
+++ b/tests/Migrations/MySQL/DatetimeMicrosecondsTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Migrations\Tests\MySQL;
+
+/**
+ * @group driver
+ * @group driver-mysql
+ */
+class DatetimeMicrosecondsTest extends \Cycle\Migrations\Tests\DatetimeMicrosecondsTest
+{
+    public const DRIVER = 'mysql';
+}

--- a/tests/Migrations/Postgres/DatetimeMicrosecondsTest.php
+++ b/tests/Migrations/Postgres/DatetimeMicrosecondsTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Migrations\Tests\Postgres;
+
+/**
+ * @group driver
+ * @group driver-postgres
+ */
+class DatetimeMicrosecondsTest extends \Cycle\Migrations\Tests\DatetimeMicrosecondsTest
+{
+    public const DRIVER = 'postgres';
+}

--- a/tests/Migrations/SQLServer/DatetimeMicrosecondsTest.php
+++ b/tests/Migrations/SQLServer/DatetimeMicrosecondsTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Migrations\Tests\SQLServer;
+
+/**
+ * @group driver
+ * @group driver-sqlserver
+ */
+class DatetimeMicrosecondsTest extends \Cycle\Migrations\Tests\DatetimeMicrosecondsTest
+{
+    public const DRIVER = 'sqlserver';
+}

--- a/tests/Migrations/SQLite/DatetimeMicrosecondsTest.php
+++ b/tests/Migrations/SQLite/DatetimeMicrosecondsTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Migrations\Tests\SQLite;
+
+/**
+ * @group driver
+ * @group driver-sqlite
+ */
+class DatetimeMicrosecondsTest extends \Cycle\Migrations\Tests\DatetimeMicrosecondsTest
+{
+    public const DRIVER = 'sqlite';
+}


### PR DESCRIPTION
## 🔍 What was changed

- `Migrator::fetchMigrationData()` passes `created_at` to the `WHERE` clause as a `DateTimeInterface` instead of a pre-formatted string, so the driver formats it exactly as it did on insert. Previously, with `withDatetimeMicroseconds` enabled, the stored value (`...12:30:45.000000`) never matched the lookup string (`...12:30:45`) on SQLite, so executed migrations were resolved as pending and re-run.
- The migration table's datetime columns are now declared with `datetime(6)`. On SQL Server the legacy `DATETIME` type rejects values with six fractional digits, so with the option enabled even the bookkeeping insert failed; `datetime2(6)` accepts them.
- `isConfigured()` additionally compares the existing migration table with the declared schema, so tables created by previous versions are upgraded on `configure()`.

### How it works

- On SQL Server and Postgres the schema comparator detects the precision change and `configure()` alters the table once; the check then passes.
- MySQL and SQLite exclude column size from comparison, so existing tables keep their columns — both work with either datetime format as is.

## Review notes

- Rows written while the option was toggled to a different value than the current one still won't match on SQLite (the stored text differs) — that pre-existing limitation is out of scope here.

## Checklist

- Closes cycle/migrations#66
- How was this tested:
  - [x] Unit tests added (fail on the previous behavior: SQLite failed all, SQL Server failed on insert)
  - [x] Full test suites run locally against SQLite, MySQL, Postgres and SQL Server